### PR TITLE
fix: omit headers when header obj is empty

### DIFF
--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@api7-dashboard/plugin",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "description": "@api7-dashboard/plugin",
   "repository": {
     "type": "git",

--- a/packages/plugin/src/transformer.ts
+++ b/packages/plugin/src/transformer.ts
@@ -1,4 +1,5 @@
 import setValue from 'set-value';
+import { omit, isEmpty } from 'lodash';
 
 import { SCHEMA_REQUEST_VALIDATION } from './data'
 
@@ -52,6 +53,11 @@ const requestRewriteHeader = (data: any) => {
     headers[item.key] = item.value;
   });
   setValue(data, 'headers', headers);
+
+  if (isEmpty(headers)) {
+    return omit(data, ['headers']);
+  }
+
   return data;
 };
 


### PR DESCRIPTION
### Reproduce steps

1. login http://139.217.190.60/ , create a route, enable proxy-rewrite or response-rewrite plugin, and did not rewrite headers
![image](https://user-images.githubusercontent.com/2561857/98898870-89a1e300-24e9-11eb-9691-12958f387dcb.png)

1. submit , and got an error:
![image](https://user-images.githubusercontent.com/2561857/98898962-b0f8b000-24e9-11eb-8a64-a80fdf730f94.png)


### Analysis
as the [doc](https://github.com/apache/apisix/blob/master/doc/zh-cn/plugins/response-rewrite.md#%E9%85%8D%E7%BD%AE%E5%8F%82%E6%95%B0) says, `headers` is an optional item, but when config `headers`, there should be at least one property

then check the data posted to api:
![image](https://user-images.githubusercontent.com/2561857/98899419-7e9b8280-24ea-11eb-99a8-bc2e1b036fc6.png)

### Fix

when `headers` did not be rewrited, omit it.

