### PR TITLE
fix: when plugin data is not empty, close panel also needs data trans…

### DIFF
--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@api7-dashboard/plugin",
-  "version": "1.0.14",
+  "version": "1.0.15",
   "description": "@api7-dashboard/plugin",
   "repository": {
     "type": "git",

--- a/packages/plugin/src/PluginPage.tsx
+++ b/packages/plugin/src/PluginPage.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { EyeFilled, SettingFilled } from '@ant-design/icons';
 import { JSONSchema7 } from 'json-schema';
 import { Anchor, Layout, Switch, Card, Tooltip, Button, notification, Avatar } from 'antd';
-import { omit } from 'lodash';
+import { omit, isEmpty } from 'lodash';
 import Ajv from 'ajv';
 
 // @ts-ignore
@@ -43,7 +43,6 @@ const PluginPageApp: React.FC<Props> = ({ initialData = {}, readonly, onChange =
   }, [initialData]);
 
   const ajv = new Ajv();
-
   return (
     <>
       <style>{`
@@ -171,6 +170,13 @@ const PluginPageApp: React.FC<Props> = ({ initialData = {}, readonly, onChange =
         readonly={readonly}
         schema={schema!}
         onClose={() => {
+          // when data is not empty, close panel also needs data transform
+          if (!isEmpty(initialData) && !isEmpty(initialData[pluginName!])) {
+            onChange({
+              ...initialData,
+              [pluginName!]: transformPlugin(pluginName!, initialData[pluginName!], 'request'),
+            });
+          }
           setPluginName(undefined);
         }}
         onFinish={(value) => {

--- a/packages/plugin/src/PluginPage.tsx
+++ b/packages/plugin/src/PluginPage.tsx
@@ -172,10 +172,7 @@ const PluginPageApp: React.FC<Props> = ({ initialData = {}, readonly, onChange =
         onClose={() => {
           // when data is not empty, close panel also needs data transform
           if (!isEmpty(initialData) && !isEmpty(initialData[pluginName!])) {
-            onChange({
-              ...initialData,
-              [pluginName!]: transformPlugin(pluginName!, initialData[pluginName!], 'request'),
-            });
+            transformPlugin(pluginName!, initialData[pluginName!], 'request');
           }
           setPluginName(undefined);
         }}


### PR DESCRIPTION
fix: https://github.com/apache/apisix-dashboard/issues/805

Bug cause:
`proxy-rewrite` and others plugins which did schema transform in fe, did not do request transform after `Cancel clicked` , but when open the plugin config draw, they did response transform. 

